### PR TITLE
Add a Reusable Bytes Buffer

### DIFF
--- a/bitfields/bitlist_test.go
+++ b/bitfields/bitlist_test.go
@@ -36,7 +36,7 @@ func TestBitlistLen(t *testing.T) {
 				}
 			})
 			t.Run(fmt.Sprintf("check valid %v", testCase.valid), func(t *testing.T) {
-				if err := BitlistCheck(testCase.v); err != nil && testCase.valid {
+				if err := BitlistCheck(testCase.v, testCase.n); err != nil && testCase.valid {
 					t.Errorf("expected bitlist to be valid but got error: %v", err)
 				} else if err == nil && !testCase.valid {
 					t.Error("expected bitlist to be invalid but got no error")

--- a/htr/hash_tree_root.go
+++ b/htr/hash_tree_root.go
@@ -6,9 +6,24 @@ import (
 	"unsafe"
 )
 
-type HashTreeRootFn func(hfn HashFn, pointer unsafe.Pointer) [32]byte
+func init() {
+	InitZeroHashes(NewHasherFunc(sha256.Sum256))
+}
+
+type HashTreeRootFn func(hfn Hasher, pointer unsafe.Pointer) [32]byte
 
 type HashFn func(input []byte) [32]byte
+
+type Hasher interface {
+	Hash(a []byte) [32]byte
+	Combi(a [32]byte, b [32]byte) [32]byte
+	MixIn(a [32]byte, i uint64) [32]byte
+}
+
+type HasherFunc struct {
+	b        [64]byte
+	hashFunc HashFn
+}
 
 // Excluding the full zero bytes32 itself
 const zeroHashesLevels = 64
@@ -16,31 +31,34 @@ const zeroHashesLevels = 64
 var ZeroHashes [][32]byte
 
 // initialize the zero-hashes pre-computed data with the given hash-function.
-func InitZeroHashes(hFn HashFn) {
+func InitZeroHashes(hFn Hasher) {
 	ZeroHashes = make([][32]byte, zeroHashesLevels+1)
 	v := [64]byte{}
 	for i := 0; i < zeroHashesLevels; i++ {
 		copy(v[:32], ZeroHashes[i][:])
 		copy(v[32:], ZeroHashes[i][:])
-		ZeroHashes[i+1] = hFn(v[:])
+		ZeroHashes[i+1] = hFn.Hash(v[:])
 	}
 }
-
-func init() {
-	InitZeroHashes(sha256.Sum256)
+func NewHasherFunc(h HashFn) *HasherFunc {
+	return &HasherFunc{
+		b:        [64]byte{},
+		hashFunc: h,
+	}
+}
+func (h *HasherFunc) Hash(a []byte) [32]byte {
+	return h.hashFunc(a)
 }
 
-func (h HashFn) Combi(a [32]byte, b [32]byte) [32]byte {
-	v := [64]byte{}
-	copy(v[:32], a[:])
-	copy(v[32:], b[:])
-	return h(v[:])
+func (h *HasherFunc) Combi(a [32]byte, b [32]byte) [32]byte {
+	copy(h.b[:32], a[:])
+	copy(h.b[32:], b[:])
+	return h.Hash(h.b[:])
 }
 
-func (h HashFn) MixIn(a [32]byte, i uint64) [32]byte {
-	v := [64]byte{}
-	copy(v[:32], a[:])
-	copy(v[32:], make([]byte, 32, 32))
-	binary.LittleEndian.PutUint64(v[32:], i)
-	return h(v[:])
+func (h *HasherFunc) MixIn(a [32]byte, i uint64) [32]byte {
+	copy(h.b[:32], a[:])
+	copy(h.b[32:], make([]byte, 32, 32))
+	binary.LittleEndian.PutUint64(h.b[32:], i)
+	return h.Hash(h.b[:])
 }

--- a/htr/hash_tree_root.go
+++ b/htr/hash_tree_root.go
@@ -14,6 +14,8 @@ type HashTreeRootFn func(hfn Hasher, pointer unsafe.Pointer) [32]byte
 
 type HashFn func(input []byte) [32]byte
 
+// Hasher describes an interface through which we can
+// perform hash operations on byte arrays,indices,etc.
 type Hasher interface {
 	Hash(a []byte) [32]byte
 	Combi(a [32]byte, b [32]byte) [32]byte
@@ -40,12 +42,18 @@ func InitZeroHashes(hFn Hasher) {
 		ZeroHashes[i+1] = hFn.Hash(v[:])
 	}
 }
+
+// NewHasherFunc is the constructor for the object
+// that fulfills the Hasher interface.
 func NewHasherFunc(h HashFn) *HasherFunc {
 	return &HasherFunc{
 		b:        [64]byte{},
 		hashFunc: h,
 	}
 }
+
+// Hash utilizes the provided hash function for
+// the object.
 func (h *HasherFunc) Hash(a []byte) [32]byte {
 	return h.hashFunc(a)
 }

--- a/merkle/merkleize.go
+++ b/merkle/merkleize.go
@@ -60,7 +60,7 @@ func GetDepth(v uint64) (out uint8) {
 }
 
 // Merkleize with log(N) space allocation
-func Merkleize(hasher HashFn, count uint64, limit uint64, leaf func(i uint64) []byte) (out [32]byte) {
+func Merkleize(hasher Hasher, count uint64, limit uint64, leaf func(i uint64) []byte) (out [32]byte) {
 	if count > limit {
 		panic("merkleizing list that is too large, over limit")
 	}
@@ -126,7 +126,7 @@ func Merkleize(hasher HashFn, count uint64, limit uint64, leaf func(i uint64) []
 
 // ConstructProof builds a merkle-branch of the given depth, at the given index (at that depth),
 // for a list of leafs of a balanced binary tree.
-func ConstructProof(hasher HashFn, count uint64, limit uint64, leaf func(i uint64) []byte, index uint64) (branch [][32]byte) {
+func ConstructProof(hasher Hasher, count uint64, limit uint64, leaf func(i uint64) []byte, index uint64) (branch [][32]byte) {
 	if count > limit {
 		panic("merkleizing list that is too large, over limit")
 	}

--- a/types/basic_series.go
+++ b/types/basic_series.go
@@ -47,7 +47,7 @@ func LittleEndianBasicSeriesDecode(dr *DecodingReader, p unsafe.Pointer, bytesLe
 }
 
 // WARNING: for little-endian architectures only, or the elem-length has to be 1 byte
-func LittleEndianBasicSeriesHTR(h HashFn, p unsafe.Pointer, bytesLen uint64, bytesLimit uint64) [32]byte {
+func LittleEndianBasicSeriesHTR(h Hasher, p unsafe.Pointer, bytesLen uint64, bytesLimit uint64) [32]byte {
 	bytesSh := ptrutil.GetSliceHeader(p, bytesLen)
 	data := *(*[]byte)(unsafe.Pointer(bytesSh))
 
@@ -83,7 +83,7 @@ func BigToLittleEndianChunk(data [32]byte, elemSize uint8) (out [32]byte) {
 }
 
 // counter-part of LittleEndianBasicSeriesHTR
-func BigEndianBasicSeriesHTR(h HashFn, p unsafe.Pointer, bytesLen uint64, bytesLimit uint64, elemSize uint8) [32]byte {
+func BigEndianBasicSeriesHTR(h Hasher, p unsafe.Pointer, bytesLen uint64, bytesLimit uint64, elemSize uint8) [32]byte {
 	bytesSh := ptrutil.GetSliceHeader(p, bytesLen)
 	data := *(*[]byte)(unsafe.Pointer(bytesSh))
 

--- a/types/ssz_basic.go
+++ b/types/ssz_basic.go
@@ -62,7 +62,7 @@ func (v *SSZBasic) DryCheck(dr *DecodingReader) error {
 	return v.DryChecker(dr)
 }
 
-func (v *SSZBasic) HashTreeRoot(h HashFn, pointer unsafe.Pointer) [32]byte {
+func (v *SSZBasic) HashTreeRoot(h Hasher, pointer unsafe.Pointer) [32]byte {
 	return v.HTR(pointer)
 }
 

--- a/types/ssz_bitlist.go
+++ b/types/ssz_bitlist.go
@@ -138,7 +138,7 @@ func (v *SSZBitlist) DryCheck(dr *DecodingReader) error {
 	return bitfields.BitlistCheckLastByte(last, v.bitLimit-((span-1)<<3))
 }
 
-func (v *SSZBitlist) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZBitlist) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	sh := ptrutil.ReadSliceHeader(p)
 	data := *(*[]byte)(unsafe.Pointer(sh))
 	bitLen := bitfields.BitlistLen(data)

--- a/types/ssz_bitvector.go
+++ b/types/ssz_bitvector.go
@@ -107,7 +107,7 @@ func (v *SSZBitvector) DryCheck(dr *DecodingReader) error {
 	return bitfields.BitvectorCheckLastByte(last, v.bitLen)
 }
 
-func (v *SSZBitvector) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZBitvector) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	sh := ptrutil.GetSliceHeader(p, v.byteLen)
 	data := *(*[]byte)(unsafe.Pointer(sh))
 	leafCount := (v.byteLen + 31) >> 5

--- a/types/ssz_bytes.go
+++ b/types/ssz_bytes.go
@@ -96,7 +96,7 @@ func (v *SSZBytes) DryCheck(dr *DecodingReader) error {
 	return err
 }
 
-func (v *SSZBytes) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZBytes) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	sh := ptrutil.ReadSliceHeader(p)
 	data := *(*[]byte)(unsafe.Pointer(sh))
 	dataLen := uint64(len(data))

--- a/types/ssz_bytes_n.go
+++ b/types/ssz_bytes_n.go
@@ -74,7 +74,7 @@ func (v *SSZBytesN) DryCheck(dr *DecodingReader) error {
 	return err
 }
 
-func (v *SSZBytesN) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZBytesN) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	sh := ptrutil.GetSliceHeader(p, v.length)
 	data := *(*[]byte)(unsafe.Pointer(sh))
 	leafCount := (v.length + 31) >> 5

--- a/types/ssz_container.go
+++ b/types/ssz_container.go
@@ -333,7 +333,7 @@ func (v *SSZContainer) DryCheck(dr *DecodingReader) error {
 	})
 }
 
-func (v *SSZContainer) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZContainer) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	leaf := func(i uint64) []byte {
 		f := v.Fields[i]
 		r := f.ssz.HashTreeRoot(h, f.ptrFn(p))
@@ -343,7 +343,7 @@ func (v *SSZContainer) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
 	return merkle.Merkleize(h, leafCount, leafCount, leaf)
 }
 
-func (v *SSZContainer) SigningRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZContainer) SigningRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	leaf := func(i uint64) []byte {
 		f := v.Fields[i]
 		r := f.ssz.HashTreeRoot(h, f.ptrFn(p))

--- a/types/ssz_list.go
+++ b/types/ssz_list.go
@@ -152,7 +152,7 @@ func (v *SSZList) DryCheck(dr *DecodingReader) error {
 	}
 }
 
-func (v *SSZList) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZList) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	elemHtr := v.elemSSZ.HashTreeRoot
 	elemSize := v.elemMemSize
 	sh := ptrutil.ReadSliceHeader(p)

--- a/types/ssz_list_basic.go
+++ b/types/ssz_list_basic.go
@@ -147,7 +147,7 @@ func (v *SSZBasicList) DryCheck(dr *DecodingReader) error {
 	return BasicSeriesDryCheck(dr, bytesLen, bytesLimit, v.elemKind == reflect.Bool)
 }
 
-func (v *SSZBasicList) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZBasicList) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	sh := ptrutil.ReadSliceHeader(p)
 
 	bytesLen := uint64(sh.Len) * v.elemSSZ.Length

--- a/types/ssz_ptr.go
+++ b/types/ssz_ptr.go
@@ -75,7 +75,7 @@ func (v *SSZPtr) DryCheck(dr *DecodingReader) error {
 	return v.elemSSZ.DryCheck(dr)
 }
 
-func (v *SSZPtr) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZPtr) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	innerPtr := unsafe.Pointer(*(*uintptr)(p))
 	return v.elemSSZ.HashTreeRoot(h, innerPtr)
 }

--- a/types/ssz_typ.go
+++ b/types/ssz_typ.go
@@ -58,7 +58,7 @@ type SSZMemory interface {
 	// Reads from input, populates object with read data
 	Decode(dr *DecodingReader, p unsafe.Pointer) error
 	// Hashes the object read at the given pointer
-	HashTreeRoot(h HashFn, pointer unsafe.Pointer) [32]byte
+	HashTreeRoot(h Hasher, pointer unsafe.Pointer) [32]byte
 	// Pretty print
 	Pretty(indent uint32, w *PrettyWriter, p unsafe.Pointer)
 	//// Diff two objects
@@ -74,5 +74,5 @@ type SSZ interface {
 // SSZ definitions may also provide a way to compute a special hash-tree-root, for self-signed objects.
 type SignedSSZ interface {
 	SSZ
-	SigningRoot(h HashFn, p unsafe.Pointer) [32]byte
+	SigningRoot(h Hasher, p unsafe.Pointer) [32]byte
 }

--- a/types/ssz_vector.go
+++ b/types/ssz_vector.go
@@ -129,7 +129,7 @@ func (v *SSZVector) DryCheck(dr *DecodingReader) error {
 	}
 }
 
-func (v *SSZVector) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZVector) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	elemHtr := v.elemSSZ.HashTreeRoot
 	elemSize := v.elemMemSize
 	leaf := func(i uint64) []byte {

--- a/types/ssz_vector_basic.go
+++ b/types/ssz_vector_basic.go
@@ -93,7 +93,7 @@ func (v *SSZBasicVector) DryCheck(dr *DecodingReader) error {
 	return BasicSeriesDryCheck(dr, v.byteLen, v.byteLen, v.elemKind == reflect.Bool)
 }
 
-func (v *SSZBasicVector) HashTreeRoot(h HashFn, p unsafe.Pointer) [32]byte {
+func (v *SSZBasicVector) HashTreeRoot(h Hasher, p unsafe.Pointer) [32]byte {
 	if endianness.IsLittleEndian || v.elemSSZ.Length == 1 {
 		return LittleEndianBasicSeriesHTR(h, p, v.byteLen, v.byteLen)
 	} else {

--- a/zssz.go
+++ b/zssz.go
@@ -106,7 +106,7 @@ func Pretty(w io.Writer, indent string, val interface{}, sszTyp SSZ) {
 	runtime.KeepAlive(&val)
 }
 
-func HashTreeRoot(h HashFn, val interface{}, sszTyp SSZ) [32]byte {
+func HashTreeRoot(h Hasher, val interface{}, sszTyp SSZ) [32]byte {
 	p := ptrutil.IfacePtrToPtr(&val)
 	out := sszTyp.HashTreeRoot(h, p)
 	// make sure the data of the object is kept around up to this point.
@@ -114,7 +114,7 @@ func HashTreeRoot(h HashFn, val interface{}, sszTyp SSZ) [32]byte {
 	return out
 }
 
-func SigningRoot(h HashFn, val interface{}, sszTyp SignedSSZ) [32]byte {
+func SigningRoot(h Hasher, val interface{}, sszTyp SignedSSZ) [32]byte {
 	p := ptrutil.IfacePtrToPtr(&val)
 	out := sszTyp.SigningRoot(h, p)
 	// make sure the data of the object is kept around up to this point.

--- a/zssz_test.go
+++ b/zssz_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/protolambda/zssz/bitfields"
+	"github.com/protolambda/zssz/htr"
 	. "github.com/protolambda/zssz/types"
 	"reflect"
 	"strings"
@@ -690,6 +691,7 @@ func TestHashTreeRoot(t *testing.T) {
 		copy(out[:], sha.Sum(nil))
 		return
 	}
+	hasher := htr.NewHasherFunc(hashFn)
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -698,7 +700,7 @@ func TestHashTreeRoot(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			root := HashTreeRoot(hashFn, tt.value, sszTyp)
+			root := HashTreeRoot(hasher, tt.value, sszTyp)
 			res := hex.EncodeToString(root[:])
 			if res != tt.root {
 				t.Errorf("Expected root %s but got %s", tt.root, res)
@@ -718,6 +720,7 @@ func TestSigningRoot(t *testing.T) {
 		copy(out[:], sha.Sum(nil))
 		return
 	}
+	hasher := htr.NewHasherFunc(hashFn)
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -731,7 +734,7 @@ func TestSigningRoot(t *testing.T) {
 				// only test signing root for applicable types
 				return
 			}
-			root := SigningRoot(hashFn, tt.value, signedSSZ)
+			root := SigningRoot(hasher, tt.value, signedSSZ)
 			res := hex.EncodeToString(root[:])
 			if res == tt.root && root != ([32]byte{}) {
 				t.Errorf("Signing root is not different than hash-tree-root. "+


### PR DESCRIPTION
- [x] The main changes from this PR allows us to utilise a reusable bytes buffer so that each time we use `Combi` or `MixIn` we do not allocate 64 bytes each time. We instead utilize a `hasher` interface which we pass down to all our methods. This was something that came up in the profiler as we were allocating a lot of memory that wasn;t need when using `merklelize`

- [x] Also fixes a missing reference in `BitlistCheck`